### PR TITLE
Separate withdraw and deposit gateway activation

### DIFF
--- a/api/api-core/src/main/kotlin/co/nilin/opex/api/core/inout/GatewayCommand.kt
+++ b/api/api-core/src/main/kotlin/co/nilin/opex/api/core/inout/GatewayCommand.kt
@@ -31,6 +31,7 @@ open abstract class CurrencyGatewayCommand(
     open var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     open var description: String? = null,
+    open var displayOrder: Int? = null,
 )
 
 data class OffChainGatewayCommand(
@@ -47,6 +48,7 @@ data class OffChainGatewayCommand(
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     override var description: String? = null,
+    override var displayOrder: Int? = null,
 
     ) : CurrencyGatewayCommand(
     currencySymbol,
@@ -60,7 +62,8 @@ data class OffChainGatewayCommand(
     depositMax,
     withdrawMin,
     withdrawMax,
-    description
+    description,
+    displayOrder
 )
 
 data class OnChainGatewayCommand(
@@ -83,6 +86,7 @@ data class OnChainGatewayCommand(
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     override var description: String? = null,
+    override var displayOrder: Int? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
@@ -95,7 +99,8 @@ data class OnChainGatewayCommand(
     depositMax,
     withdrawMin,
     withdrawMax,
-    description
+    description,
+    displayOrder
 )
 
 

--- a/api/api-core/src/main/kotlin/co/nilin/opex/api/core/inout/GatewayCommand.kt
+++ b/api/api-core/src/main/kotlin/co/nilin/opex/api/core/inout/GatewayCommand.kt
@@ -21,7 +21,8 @@ enum class GatewayType() {
 open abstract class CurrencyGatewayCommand(
     open var currencySymbol: String? = null,
     open var gatewayUuid: String? = UUID.randomUUID().toString(),
-    open var isActive: Boolean?,
+    open var isDepositActive: Boolean?,
+    open var isWithdrawActive: Boolean?,
     open var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     open var withdrawAllowed: Boolean? = true,
     open var depositAllowed: Boolean? = true,
@@ -29,13 +30,15 @@ open abstract class CurrencyGatewayCommand(
     open var depositMax: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMax: BigDecimal? = BigDecimal.ZERO,
+    open var description: String? = null,
 )
 
 data class OffChainGatewayCommand(
     var transferMethod: TransferMethod,
     override var currencySymbol: String? = null,
     override var gatewayUuid: String? = UUID.randomUUID().toString(),
-    override var isActive: Boolean? = true,
+    override var isDepositActive: Boolean? = true,
+    override var isWithdrawActive: Boolean? = true,
     override var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     override var withdrawAllowed: Boolean? = true,
     override var depositAllowed: Boolean? = true,
@@ -43,17 +46,21 @@ data class OffChainGatewayCommand(
     override var depositMax: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
-) : CurrencyGatewayCommand(
+    override var description: String? = null,
+
+    ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
-    isActive,
+    isDepositActive,
+    isWithdrawActive,
     withdrawFee,
     withdrawAllowed,
     depositAllowed,
     depositMin,
     depositMax,
     withdrawMin,
-    withdrawMax
+    withdrawMax,
+    description
 )
 
 data class OnChainGatewayCommand(
@@ -66,7 +73,8 @@ data class OnChainGatewayCommand(
     var chain: String,
     override var currencySymbol: String? = null,
     override var gatewayUuid: String? = UUID.randomUUID().toString(),
-    override var isActive: Boolean? = true,
+    override var isDepositActive: Boolean? = true,
+    override var isWithdrawActive: Boolean? = true,
     override var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     override var withdrawAllowed: Boolean? = true,
     override var depositAllowed: Boolean? = true,
@@ -74,17 +82,20 @@ data class OnChainGatewayCommand(
     override var depositMax: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
+    override var description: String? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
-    isActive,
+    isDepositActive,
+    isWithdrawActive,
     withdrawFee,
     withdrawAllowed,
     depositAllowed,
     depositMin,
     depositMax,
     withdrawMin,
-    withdrawMax
+    withdrawMax,
+    description
 )
 
 

--- a/bc-gateway/bc-gateway-core/src/main/kotlin/co/nilin/opex/bcgateway/core/model/CryptoCurrencyCommand.kt
+++ b/bc-gateway/bc-gateway-core/src/main/kotlin/co/nilin/opex/bcgateway/core/model/CryptoCurrencyCommand.kt
@@ -21,6 +21,7 @@ data class CryptoCurrencyCommand(
     var decimal: Int,
     var chain: String,
     var description: String?,
+    var displayOrder: Int? = null,
     var type: String = "OnChain",
 
 //        var chainDetail: Chain? = null

--- a/bc-gateway/bc-gateway-core/src/main/kotlin/co/nilin/opex/bcgateway/core/model/CryptoCurrencyCommand.kt
+++ b/bc-gateway/bc-gateway-core/src/main/kotlin/co/nilin/opex/bcgateway/core/model/CryptoCurrencyCommand.kt
@@ -6,7 +6,8 @@ data class CryptoCurrencyCommand(
     var currencySymbol: String,
     var gatewayUuid: String?,
     var implementationSymbol: String? = currencySymbol,
-    var isActive: Boolean? = true,
+    var isDepositActive: Boolean? = true,
+    var isWithdrawActive: Boolean? = true,
     var isToken: Boolean? = false,
     var tokenName: String? = null,
     var tokenAddress: String? = null,
@@ -19,7 +20,8 @@ data class CryptoCurrencyCommand(
     var depositMax: BigDecimal? = BigDecimal.ZERO,
     var decimal: Int,
     var chain: String,
-    var type: String = "OnChain"
+    var description: String?,
+    var type: String = "OnChain",
 
 //        var chainDetail: Chain? = null
 

--- a/bc-gateway/bc-gateway-core/src/test/kotlin/co/nilin/opex/bcgateway/core/service/AssignAddressServiceImplUnitTest.kt
+++ b/bc-gateway/bc-gateway-core/src/test/kotlin/co/nilin/opex/bcgateway/core/service/AssignAddressServiceImplUnitTest.kt
@@ -40,6 +40,7 @@ class AssignAddressServiceImplUnitTest {
             UUID.randomUUID().toString(),
             currency,
             true,
+            true,
             false,
             null,
             null,
@@ -52,6 +53,7 @@ class AssignAddressServiceImplUnitTest {
             BigDecimal.ZERO,
             18,
             ethChain.name,
+            null
 //                ethChain
         )
 
@@ -60,6 +62,7 @@ class AssignAddressServiceImplUnitTest {
             currency,
             UUID.randomUUID().toString(),
             currency,
+            true,
             true,
             false,
             "WETH",
@@ -73,6 +76,7 @@ class AssignAddressServiceImplUnitTest {
             BigDecimal.ZERO,
             18,
             bscChain.name,
+            null
 //                bscChain
 
         )

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/dao/CurrencyImplementationRepository.kt
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/dao/CurrencyImplementationRepository.kt
@@ -13,7 +13,7 @@ interface CurrencyImplementationRepository : ReactiveCrudRepository<CurrencyOnCh
 
     fun findByGatewayUuid(uuid: String): Mono<CurrencyOnChainGatewayModel>?
 
-    @Query("select * from currency_on_chain_gateway where (:gatewayUuid is null or gateway_uuid=:gatewayUuid) and (:currencySymbol is null or currency_symbol=:currencySymbol ) and (:implementationSymbol is null or implementation_symbol=:implementationSymbol ) and (:chain is null or chain=:chain )  ")
+    @Query("select * from currency_on_chain_gateway where (:gatewayUuid is null or gateway_uuid=:gatewayUuid) and (:currencySymbol is null or currency_symbol=:currencySymbol ) and (:implementationSymbol is null or implementation_symbol=:implementationSymbol ) and (:chain is null or chain=:chain ) order by display_order")
     fun findGateways(
         currencySymbol: String? = null,
         gatewayUuid: String? = null,

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/model/CurrencyOnChainGatewayModel.kt
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/model/CurrencyOnChainGatewayModel.kt
@@ -26,6 +26,7 @@ class CurrencyOnChainGatewayModel(
     @Column("is_deposit_active") var isDepositActive: Boolean? = true,
     @Column("is_withdraw_active") var isWithdrawActive: Boolean? = true,
     @Column("description") val description: String?,
+    @Column("display_order") val displayOrder: Int? = null,
 
     )
 

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/model/CurrencyOnChainGatewayModel.kt
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/model/CurrencyOnChainGatewayModel.kt
@@ -23,8 +23,9 @@ class CurrencyOnChainGatewayModel(
     @Column("withdraw_max") var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     @Column("deposit_min") var depositMin: BigDecimal? = BigDecimal.ZERO,
     @Column("deposit_max") var depositMax: BigDecimal? = BigDecimal.ZERO, @Column("decimal") var decimal: Int,
-    @Column("is_active") var isActive: Boolean? = true,
-
+    @Column("is_deposit_active") var isDepositActive: Boolean? = true,
+    @Column("is_withdraw_active") var isWithdrawActive: Boolean? = true,
+    @Column("description") val description: String?,
 
     )
 

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/util/convertor.kt
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/util/convertor.kt
@@ -21,7 +21,9 @@ fun CryptoCurrencyCommand.toModel(): CurrencyOnChainGatewayModel {
         depositMin,
         depositMax,
         decimal,
-        isActive
+        isDepositActive,
+        isWithdrawActive,
+        description,
     )
 }
 
@@ -31,7 +33,8 @@ fun CurrencyOnChainGatewayModel.toDto(): CryptoCurrencyCommand {
         currencySymbol,
         gatewayUuid!!,
         implementationSymbol,
-        isActive,
+        isDepositActive,
+        isWithdrawActive,
         isToken,
         tokenName,
         tokenAddress,
@@ -43,7 +46,8 @@ fun CurrencyOnChainGatewayModel.toDto(): CryptoCurrencyCommand {
         depositMin,
         depositMax,
         decimal,
-        chain
+        chain,
+        description,
     )
 
 }

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/util/convertor.kt
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/kotlin/co/nilin/opex/bcgateway/ports/postgres/util/convertor.kt
@@ -24,6 +24,7 @@ fun CryptoCurrencyCommand.toModel(): CurrencyOnChainGatewayModel {
         isDepositActive,
         isWithdrawActive,
         description,
+        displayOrder,
     )
 }
 
@@ -48,7 +49,9 @@ fun CurrencyOnChainGatewayModel.toDto(): CryptoCurrencyCommand {
         decimal,
         chain,
         description,
-    )
+        displayOrder,
+
+        )
 
 }
 

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/resources/schema.sql
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/resources/schema.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS currency_on_chain_gateway
     is_deposit_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
     is_withdraw_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
     description            TEXT,
+    display_order     INTEGER,
     UNIQUE (currency_symbol, chain, implementation_symbol)
 );
 
@@ -103,18 +104,23 @@ BEGIN
         IF NOT EXISTS (SELECT 1
                        FROM information_schema.columns
                        WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'is_deposit_active') THEN ALTER TABLE currency_on_chain_gateway
-    ADD COLUMN is_deposit_active Boolean NOT NULL DEFAULT TRUE;
-END IF;
+        ADD COLUMN is_deposit_active Boolean NOT NULL DEFAULT TRUE;
+        END IF;
         IF EXISTS (SELECT 1
                                FROM information_schema.columns
                                WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'is_active') THEN ALTER TABLE currency_on_chain_gateway
-    RENAME COLUMN is_active TO is_withdraw_active;
-END IF;
+        RENAME COLUMN is_active TO is_withdraw_active;
+        END IF;
         IF NOT EXISTS (SELECT 1
                        FROM information_schema.columns
                        WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'description') THEN ALTER TABLE currency_on_chain_gateway
-    ADD COLUMN description TEXT;
-END IF;
+        ADD COLUMN description TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'display_order') THEN ALTER TABLE currency_on_chain_gateway
+        ADD COLUMN display_order INTEGER;
+        END IF;
 END
 $$;
 

--- a/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/resources/schema.sql
+++ b/bc-gateway/bc-gateway-ports/bc-gateway-persister-postgres/src/main/resources/schema.sql
@@ -77,7 +77,9 @@ CREATE TABLE IF NOT EXISTS currency_on_chain_gateway
     deposit_min           DECIMAL      NOT NULL,
     deposit_max           DECIMAL      NOT NULL,
     decimal               INTEGER      NOT NULL,
-    is_active             BOOLEAN      NOT NULL        DEFAULT TRUE,
+    is_deposit_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
+    is_withdraw_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
+    description            TEXT,
     UNIQUE (currency_symbol, chain, implementation_symbol)
 );
 
@@ -95,5 +97,25 @@ CREATE TABLE IF NOT EXISTS deposits
     depositor_memo VARCHAR(72)
 );
 
+DO
+$$
+BEGIN
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'is_deposit_active') THEN ALTER TABLE currency_on_chain_gateway
+    ADD COLUMN is_deposit_active Boolean NOT NULL DEFAULT TRUE;
+END IF;
+        IF EXISTS (SELECT 1
+                               FROM information_schema.columns
+                               WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'is_active') THEN ALTER TABLE currency_on_chain_gateway
+    RENAME COLUMN is_active TO is_withdraw_active;
+END IF;
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_on_chain_gateway' AND column_name = 'description') THEN ALTER TABLE currency_on_chain_gateway
+    ADD COLUMN description TEXT;
+END IF;
+END
+$$;
 
 

--- a/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/CurrencyServiceV2.kt
+++ b/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/CurrencyServiceV2.kt
@@ -69,10 +69,10 @@ class CurrencyServiceV2(
                 var gateways = gatewayService.fetchGateways(currencySymbol, includeGateways)
                 return it.apply {
                     it.depositAllowed =
-                        gateways?.stream()?.filter { it.isActive == true }?.map(CurrencyGatewayCommand::depositAllowed)
+                        gateways?.stream()?.filter { it.isDepositActive == true }?.map(CurrencyGatewayCommand::depositAllowed)
                             ?.reduce { t, u -> t ?: false || u ?: false }?.orElseGet { false }
                     it.withdrawAllowed =
-                        gateways?.stream()?.filter { it.isActive == true }?.map(CurrencyGatewayCommand::withdrawAllowed)
+                        gateways?.stream()?.filter { it.isWithdrawActive == true }?.map(CurrencyGatewayCommand::withdrawAllowed)
                             ?.reduce { t, u -> t ?: false || u ?: false }?.orElseGet { false }
                     it.gateways = gateways
                     //It is a stupid field for resolving front-end developers need
@@ -119,10 +119,10 @@ class CurrencyServiceV2(
         return CurrenciesDto(currencies?.stream()?.map {
             it.apply {
                 it.gateways = groupedByGateways?.get(it.symbol)
-                it.depositAllowed = groupedByGateways?.get(it.symbol)?.stream()?.filter { g -> g.isActive == true }
+                it.depositAllowed = groupedByGateways?.get(it.symbol)?.stream()?.filter { g -> g.isDepositActive == true }
                     ?.map(CurrencyGatewayCommand::depositAllowed)?.reduce { t, u -> t ?: false || u ?: false }
                     ?.orElseGet { false }
-                it.withdrawAllowed = groupedByGateways?.get(it.symbol)?.stream()?.filter { g -> g.isActive == true }
+                it.withdrawAllowed = groupedByGateways?.get(it.symbol)?.stream()?.filter { g -> g.isWithdrawActive == true }
                     ?.map(CurrencyGatewayCommand::withdrawAllowed)?.reduce { t, u -> t ?: false || u ?: false }
                     ?.orElseGet { false }
                 it.gateways?.forEach { gateway ->

--- a/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/DepositService.kt
+++ b/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/DepositService.kt
@@ -165,7 +165,7 @@ class DepositService(
                         depositCommand.currency = it.currencySymbol!!
                         depositCommand.network = it.chain
                         return GatewayData(
-                            it.isActive ?: true && it.depositAllowed ?: true,
+                            it.isDepositActive ?: true && it.depositAllowed ?: true,
                             BigDecimal.ZERO,
                             it.depositMin ?: BigDecimal.ZERO,
                             it.depositMax
@@ -178,7 +178,7 @@ class DepositService(
                         depositCommand.network = null
                         depositCommand.transferMethod = it.transferMethod
                         return GatewayData(
-                            it.isActive ?: true && it.depositAllowed ?: true,
+                            it.isDepositActive ?: true && it.depositAllowed ?: true,
                             BigDecimal.ZERO,
                             it.depositMin ?: BigDecimal.ZERO,
                             it.depositMax

--- a/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/ManualWithdrawService.kt
+++ b/wallet/wallet-app/src/main/kotlin/co/nilin/opex/wallet/app/service/ManualWithdrawService.kt
@@ -36,7 +36,7 @@ class ManualWithdrawService(
             ?.takeIf { it is OffChainGatewayCommand && it.transferMethod == TransferMethod.MANUALLY }
             ?.let {
                 val gatewayData = GatewayData(
-                    it.isActive ?: true && it.withdrawAllowed ?: true,
+                    it.isWithdrawActive ?: true && it.withdrawAllowed ?: true,
                     it.withdrawFee ?: BigDecimal.ZERO,
                     it.withdrawMin ?: BigDecimal.ZERO,
                     it.withdrawMax

--- a/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/GatewayCommand.kt
+++ b/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/GatewayCommand.kt
@@ -31,6 +31,7 @@ open abstract class CurrencyGatewayCommand(
     open var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     open var description: String? = null,
+    open var displayOrder: Int? = null,
 )
 
 data class OffChainGatewayCommand(
@@ -47,6 +48,7 @@ data class OffChainGatewayCommand(
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     override var description: String? = null,
+    override var displayOrder: Int? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
@@ -59,7 +61,8 @@ data class OffChainGatewayCommand(
     depositMax,
     withdrawMin,
     withdrawMax,
-    description
+    description,
+    displayOrder
 )
 
 data class OnChainGatewayCommand(
@@ -82,6 +85,7 @@ data class OnChainGatewayCommand(
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
     override var description: String? = null,
+    override var displayOrder: Int? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
@@ -94,7 +98,8 @@ data class OnChainGatewayCommand(
     depositMax,
     withdrawMin,
     withdrawMax,
-    description
+    description,
+    displayOrder
 )
 
 

--- a/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/GatewayCommand.kt
+++ b/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/GatewayCommand.kt
@@ -21,7 +21,8 @@ enum class GatewayType() {
 open abstract class CurrencyGatewayCommand(
     open var currencySymbol: String? = null,
     open var gatewayUuid: String? = UUID.randomUUID().toString(),
-    open var isActive: Boolean?,
+    open var isDepositActive: Boolean?,
+    open var isWithdrawActive: Boolean?,
     open var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     open var withdrawAllowed: Boolean? = true,
     open var depositAllowed: Boolean? = true,
@@ -29,13 +30,15 @@ open abstract class CurrencyGatewayCommand(
     open var depositMax: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     open var withdrawMax: BigDecimal? = BigDecimal.ZERO,
+    open var description: String? = null,
 )
 
 data class OffChainGatewayCommand(
     var transferMethod: TransferMethod,
     override var currencySymbol: String? = null,
     override var gatewayUuid: String? = UUID.randomUUID().toString(),
-    override var isActive: Boolean? = true,
+    override var isDepositActive: Boolean? = true,
+    override var isWithdrawActive: Boolean? = true,
     override var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     override var withdrawAllowed: Boolean? = true,
     override var depositAllowed: Boolean? = true,
@@ -43,17 +46,20 @@ data class OffChainGatewayCommand(
     override var depositMax: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
+    override var description: String? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
-    isActive,
+    isDepositActive,
+    isWithdrawActive,
     withdrawFee,
     withdrawAllowed,
     depositAllowed,
     depositMin,
     depositMax,
     withdrawMin,
-    withdrawMax
+    withdrawMax,
+    description
 )
 
 data class OnChainGatewayCommand(
@@ -66,7 +72,8 @@ data class OnChainGatewayCommand(
     var chain: String,
     override var currencySymbol: String? = null,
     override var gatewayUuid: String? = UUID.randomUUID().toString(),
-    override var isActive: Boolean? = true,
+    override var isDepositActive: Boolean? = true,
+    override var isWithdrawActive: Boolean? = true,
     override var withdrawFee: BigDecimal? = BigDecimal.ZERO,
     override var withdrawAllowed: Boolean? = true,
     override var depositAllowed: Boolean? = true,
@@ -74,17 +81,20 @@ data class OnChainGatewayCommand(
     override var depositMax: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMin: BigDecimal? = BigDecimal.ZERO,
     override var withdrawMax: BigDecimal? = BigDecimal.ZERO,
+    override var description: String? = null,
 ) : CurrencyGatewayCommand(
     currencySymbol,
     gatewayUuid,
-    isActive,
+    isDepositActive,
+    isWithdrawActive,
     withdrawFee,
     withdrawAllowed,
     depositAllowed,
     depositMin,
     depositMax,
     withdrawMin,
-    withdrawMax
+    withdrawMax,
+    description
 )
 
 

--- a/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/TerminalCommand.kt
+++ b/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/inout/TerminalCommand.kt
@@ -7,5 +7,7 @@ data class TerminalCommand(
     var active: Boolean? = true,
     var type: TransferMethod,
     var metaData: String,
-    var description : String?
+    var description : String?,
+    var displayOrder: Int? = null,
+
 )

--- a/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/service/WithdrawService.kt
+++ b/wallet/wallet-core/src/main/kotlin/co/nilin/opex/wallet/core/service/WithdrawService.kt
@@ -126,7 +126,7 @@ class WithdrawService(
                         withdrawCommand.destSymbol = it.implementationSymbol!!
                         withdrawCommand.withdrawType = WithdrawType.ON_CHAIN
                         GatewayData(
-                            it.isActive ?: true && it.withdrawAllowed ?: true,
+                            it.isWithdrawActive ?: true && it.withdrawAllowed ?: true,
                             it.withdrawFee ?: BigDecimal.ZERO,
                             it.withdrawMin ?: BigDecimal.ZERO,
                             it.withdrawMax
@@ -139,7 +139,7 @@ class WithdrawService(
                         withdrawCommand.withdrawType = WithdrawType.OFF_CHAIN
                         withdrawCommand.transferMethod = it.transferMethod
                         GatewayData(
-                            it.isActive ?: true && it.withdrawAllowed ?: true,
+                            it.isWithdrawActive ?: true && it.withdrawAllowed ?: true,
                             it.withdrawFee ?: BigDecimal.ZERO,
                             it.withdrawMin ?: BigDecimal.ZERO,
                             it.withdrawMax

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/dao/OffChainGatewayRepository.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/dao/OffChainGatewayRepository.kt
@@ -16,7 +16,7 @@ interface OffChainGatewayRepository : ReactiveCrudRepository<OffChainGatewayMode
 
     fun deleteByGatewayUuid(uuid: String): Mono<Void>
 
-    @Query("select * from currency_off_chain_gateway where (:gatewayUuid is null or gateway_uuid=:gatewayUuid) and (:currencySymbol is null or currency_symbol=:currencySymbol )  ")
+    @Query("select * from currency_off_chain_gateway where (:gatewayUuid is null or gateway_uuid=:gatewayUuid) and (:currencySymbol is null or currency_symbol=:currencySymbol ) order by display_order")
     fun findGateways(currencySymbol: String? = null, gatewayUuid: String? = null): Flux<OffChainGatewayModel>?
 
     fun findByCurrencySymbolAndAndTransferMethod(

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/dao/TerminalRepository.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/dao/TerminalRepository.kt
@@ -3,12 +3,14 @@ package co.nilin.opex.wallet.ports.postgres.dao
 import co.nilin.opex.wallet.ports.postgres.model.TerminalModel
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @Repository
 interface TerminalRepository : ReactiveCrudRepository<TerminalModel, Long> {
     fun findByIdentifier(identifier: String): Mono<TerminalModel>?
     fun findByUuid(uuid: String): Mono<TerminalModel>?
+    fun findAllByOrderByDisplayOrder(): Flux<TerminalModel>
 
 
 }

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/impl/TerminalManagerImpl.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/impl/TerminalManagerImpl.kt
@@ -31,7 +31,7 @@ class TerminalManagerImpl(private val terminalRepository: TerminalRepository) : 
     }
 
     override suspend fun fetchTerminal(): List<TerminalCommand>? {
-        return terminalRepository.findAll().map { it.toDto() }?.collectList()?.awaitSingleOrNull()
+        return terminalRepository.findAllByOrderByDisplayOrder().map { it.toDto() }?.collectList()?.awaitSingleOrNull()
     }
 
     override suspend fun fetchTerminal(uuid: String): TerminalCommand? {

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/OffChainGatewayModel.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/OffChainGatewayModel.kt
@@ -21,6 +21,6 @@ data class OffChainGatewayModel(
     @Column("transfer_method") var transferMethod: String,
     @Column("is_deposit_active") var isDepositActive: Boolean? = true,
     @Column("is_withdraw_active") var isWithdrawActive: Boolean? = true,
-    @Column("description") val description: String?,
-
+    @Column("description") val description: String? = null,
+    @Column("display_order") val displayOrder: Int? = null,
     )

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/OffChainGatewayModel.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/OffChainGatewayModel.kt
@@ -19,5 +19,8 @@ data class OffChainGatewayModel(
     @Column("deposit_min") var depositMin: BigDecimal? = BigDecimal.ZERO,
     @Column("deposit_max") var depositMax: BigDecimal? = BigDecimal.ZERO,
     @Column("transfer_method") var transferMethod: String,
-    @Column("is_active") var isActive: Boolean? = true,
-)
+    @Column("is_deposit_active") var isDepositActive: Boolean? = true,
+    @Column("is_withdraw_active") var isWithdrawActive: Boolean? = true,
+    @Column("description") val description: String?,
+
+    )

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/TerminalModel.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/model/TerminalModel.kt
@@ -15,5 +15,6 @@ data class TerminalModel(
     var active: Boolean? = true,
     var type: TransferMethod,
     var metaData: String,
-    var description : String?
+    var description : String?,
+    var displayOrder: Int? = null,
 )

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/util/Convertor.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/util/Convertor.kt
@@ -113,7 +113,8 @@ fun OffChainGatewayModel.toDto(): CurrencyGatewayCommand {
         depositMax,
         withdrawMin,
         withdrawMax,
-        description
+        description,
+        displayOrder
     )
 
 }
@@ -133,6 +134,7 @@ fun OffChainGatewayCommand.toModel(): OffChainGatewayModel {
         isDepositActive,
         isWithdrawActive,
         description,
+        displayOrder
     )
 }
 
@@ -141,7 +143,7 @@ fun TerminalCommand.toModel(): TerminalModel {
         null,
         uuid,
         owner,
-        identifier, active, type, metaData, description
+        identifier, active, type, metaData, description,displayOrder
     )
 }
 
@@ -149,7 +151,7 @@ fun TerminalModel.toDto(): TerminalCommand {
     return TerminalCommand(
         uuid!!,
         owner,
-        identifier, active, type, metaData, description
+        identifier, active, type, metaData, description,displayOrder
     )
 }
 
@@ -169,6 +171,6 @@ fun CurrencyModel.toCurrencyData(): CurrencyData {
         shortDescription,
         externalUrl,
         order,
-        maxOrder
+        maxOrder,
     )
 }

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/util/Convertor.kt
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/kotlin/co/nilin/opex/wallet/ports/postgres/util/Convertor.kt
@@ -1,7 +1,10 @@
 package co.nilin.opex.wallet.ports.postgres.util
 
 import co.nilin.opex.wallet.core.inout.*
-import co.nilin.opex.wallet.ports.postgres.model.*
+import co.nilin.opex.wallet.ports.postgres.model.CurrencyModel
+import co.nilin.opex.wallet.ports.postgres.model.DepositModel
+import co.nilin.opex.wallet.ports.postgres.model.OffChainGatewayModel
+import co.nilin.opex.wallet.ports.postgres.model.TerminalModel
 import java.time.ZoneId
 import java.util.*
 
@@ -101,14 +104,16 @@ fun OffChainGatewayModel.toDto(): CurrencyGatewayCommand {
         TransferMethod.valueOf(transferMethod),
         currencySymbol,
         gatewayUuid,
-        isActive,
+        isDepositActive,
+        isWithdrawActive,
         withdrawFee,
         withdrawAllowed,
         depositAllowed,
         depositMin,
         depositMax,
         withdrawMin,
-        withdrawMax
+        withdrawMax,
+        description
     )
 
 }
@@ -125,7 +130,9 @@ fun OffChainGatewayCommand.toModel(): OffChainGatewayModel {
         depositMin,
         depositMax,
         transferMethod.name,
-        isActive
+        isDepositActive,
+        isWithdrawActive,
+        description,
     )
 }
 

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/resources/schema.sql
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/resources/schema.sql
@@ -208,6 +208,7 @@ CREATE TABLE IF NOT EXISTS currency_off_chain_gateway
     is_withdraw_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
     transfer_method  VARCHAR(256) NOT NULL,
     description            TEXT,
+    display_order     INTEGER,
     UNIQUE (currency_symbol, transfer_method)
 
 );
@@ -239,7 +240,8 @@ CREATE TABLE IF NOT EXISTS terminal
     identifier      VARCHAR(255) NOT NULL,
     active          BOOLEAN DEFAULT TRUE,
     type            VARCHAR(255) NOT NULL,
-    bank_swift_code VARCHAR(255) NOT NULL
+    bank_swift_code VARCHAR(255) NOT NULL,
+    display_order     INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS gateway_terminal
@@ -527,6 +529,16 @@ $$
                        FROM information_schema.columns
                        WHERE table_name = 'currency_off_chain_gateway' AND column_name = 'description') THEN ALTER TABLE currency_off_chain_gateway
         ADD COLUMN description TEXT;
+        END IF;
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_off_chain_gateway' AND column_name = 'display_order') THEN ALTER TABLE currency_off_chain_gateway
+            ADD COLUMN display_order INTEGER;
+        END IF;
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'terminal' AND column_name = 'display_order') THEN ALTER TABLE terminal
+            ADD COLUMN display_order INTEGER;
         END IF;
     END
 $$;

--- a/wallet/wallet-ports/wallet-persister-postgres/src/main/resources/schema.sql
+++ b/wallet/wallet-ports/wallet-persister-postgres/src/main/resources/schema.sql
@@ -204,8 +204,10 @@ CREATE TABLE IF NOT EXISTS currency_off_chain_gateway
     withdraw_max     DECIMAL      NOT NULL,
     deposit_min      DECIMAL      NOT NULL,
     deposit_max      DECIMAL      NOT NULL,
-    is_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
+    is_deposit_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
+    is_withdraw_active        BOOLEAN      NOT NULL        DEFAULT TRUE,
     transfer_method  VARCHAR(256) NOT NULL,
+    description            TEXT,
     UNIQUE (currency_symbol, transfer_method)
 
 );
@@ -506,4 +508,25 @@ BEGIN
     ADD COLUMN max_order DECIMAL;
 END IF;
 END
+$$;
+
+DO
+$$
+    BEGIN
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_off_chain_gateway' AND column_name = 'is_deposit_active') THEN ALTER TABLE currency_off_chain_gateway
+        ADD COLUMN is_deposit_active Boolean NOT NULL DEFAULT TRUE;
+        END IF;
+        IF EXISTS (SELECT 1
+                               FROM information_schema.columns
+                               WHERE table_name = 'currency_off_chain_gateway' AND column_name = 'is_active') THEN ALTER TABLE currency_off_chain_gateway
+        RENAME COLUMN is_active TO is_withdraw_active;
+        END IF;
+        IF NOT EXISTS (SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_name = 'currency_off_chain_gateway' AND column_name = 'description') THEN ALTER TABLE currency_off_chain_gateway
+        ADD COLUMN description TEXT;
+        END IF;
+    END
 $$;


### PR DESCRIPTION
Refactored gateway models, commands, and database schemas to replace the single isActive field with separate isDepositActive and isWithdrawActive fields. Added an optional description field to gateway entities. Updated related service logic, converters, and migration scripts to support these changes for both on-chain and off-chain gateways.