### PR TITLE
Standardize KYC level enums and add KYC event handling

### DIFF
--- a/accountant/accountant-core/src/main/kotlin/co/nilin/opex/accountant/core/model/KycLevel.kt
+++ b/accountant/accountant-core/src/main/kotlin/co/nilin/opex/accountant/core/model/KycLevel.kt
@@ -1,6 +1,6 @@
 package co.nilin.opex.accountant.core.model
 
 enum class KycLevel {
-    Level1, Level2,
+    LEVEL_1, LEVEL_2,LEVEL_3
 }
 

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/config/AppConfig.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/config/AppConfig.kt
@@ -1,9 +1,12 @@
 package co.nilin.opex.auth.config
 
+import co.nilin.opex.auth.kafka.KycLevelUpdatedKafkaListener
+import co.nilin.opex.auth.spi.KycLevelUpdatedEventListener
 import jakarta.annotation.PostConstruct
 import org.springframework.context.annotation.Configuration
 import org.bouncycastle.util.io.pem.PemObject
 import org.bouncycastle.util.io.pem.PemWriter
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import java.io.File
 import java.io.FileOutputStream
@@ -65,5 +68,14 @@ class AppConfig {
         val stringWriter = StringWriter()
         PemWriter(stringWriter).use { it.writeObject(pemObject) }
         return stringWriter.toString()
+    }
+
+    @Autowired
+    fun configureEventListeners(
+        kycLevelUpdatedKafkaListener: KycLevelUpdatedKafkaListener,
+        kycLevelUpdatedEventListener: KycLevelUpdatedEventListener
+    ) {
+        kycLevelUpdatedKafkaListener.addEventListener(kycLevelUpdatedEventListener)
+
     }
 }

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/config/KafkaListenerConfig.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/config/KafkaListenerConfig.kt
@@ -1,10 +1,8 @@
-package co.nilin.opex.profile.ports.kafka.config
+package co.nilin.opex.auth.config
 
 
-import co.nilin.opex.profile.core.data.event.KycLevelUpdatedEvent
-import co.nilin.opex.profile.core.data.event.UserCreatedEvent
-import co.nilin.opex.profile.ports.kafka.consumer.KycLevelUpdatedKafkaListener
-import co.nilin.opex.profile.ports.kafka.consumer.UserCreatedKafkaListener
+import co.nilin.opex.auth.data.KycLevelUpdatedEvent
+import co.nilin.opex.auth.kafka.KycLevelUpdatedKafkaListener
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -19,7 +17,6 @@ import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.core.ProducerFactory
 import org.springframework.kafka.listener.*
 import org.springframework.kafka.support.serializer.JsonDeserializer
 import org.springframework.util.backoff.FixedBackOff
@@ -44,58 +41,34 @@ class KafkaListenerConfig {
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to JsonDeserializer::class.java,
             JsonDeserializer.TRUSTED_PACKAGES to "co.nilin.opex.*",
-            JsonDeserializer.TYPE_MAPPINGS to "userCreatedEvent:co.nilin.opex.profile.core.data.event.UserCreatedEvent,kyc_level_updated_event:co.nilin.opex.profile.core.data.event.KycLevelUpdatedEvent"
+            JsonDeserializer.TYPE_MAPPINGS to "kyc_level_updated_event:co.nilin.opex.auth.data.KycLevelUpdatedEvent"
         )
     }
 
-    @Bean("profileConsumerFactory")
-    fun consumerFactory(@Qualifier("consumerConfigs") consumerConfigs: Map<String, Any?>): ConsumerFactory<String, UserCreatedEvent> {
-        return DefaultKafkaConsumerFactory(consumerConfigs)
-    }
-    @Bean("profileProducerFactory")
-    fun producerFactory(@Qualifier("consumerConfigs") producerConfigs: Map<String, Any>): ProducerFactory<String, UserCreatedEvent> {
-        return DefaultKafkaProducerFactory(producerConfigs)
+    @Bean("kycLevelKafkaTemplate")
+    fun kafkaTemplate(consumerConfigs: Map<String, Any?>): KafkaTemplate<String, KycLevelUpdatedEvent> {
+        return KafkaTemplate(DefaultKafkaProducerFactory(consumerConfigs))
     }
 
-    @Bean("profileKafkaTemplate")
-    fun kafkaTemplate(@Qualifier("profileProducerFactory") producerFactory: ProducerFactory<String, UserCreatedEvent>): KafkaTemplate<String, UserCreatedEvent> {
-        return KafkaTemplate(producerFactory)
-    }
-
-    @Bean("kycConsumerFactory")
+    @Bean
     fun kycConsumerFactory(@Qualifier("consumerConfigs") consumerConfigs: Map<String, Any?>): ConsumerFactory<String, KycLevelUpdatedEvent> {
         return DefaultKafkaConsumerFactory(consumerConfigs)
     }
 
     @Autowired
-    @ConditionalOnBean(UserCreatedKafkaListener::class)
-    fun configureUserCreatedListener(
-        listener: UserCreatedKafkaListener,
-        @Qualifier("profileKafkaTemplate") template: KafkaTemplate<String, UserCreatedEvent>,
-        @Qualifier("profileConsumerFactory") consumerFactory: ConsumerFactory<String, UserCreatedEvent>
-    ) {
-        val containerProps = ContainerProperties(Pattern.compile("auth"))
-        containerProps.messageListener = listener
-        val container = ConcurrentMessageListenerContainer(consumerFactory, containerProps)
-        container.setBeanName("UserCreatedKafkaListenerContainer")
-        container.commonErrorHandler = createConsumerErrorHandler(template, "auth.DLT")
-        container.start()
-    }
-
-
-    @Autowired
-    @ConditionalOnBean(KycLevelUpdatedKafkaListener::class)
-    fun configureKycLevelUpdatedListener(
+    @Bean
+    fun kycLevelUpdatedListenerContainer(
         listener: KycLevelUpdatedKafkaListener,
-        template: KafkaTemplate<String, KycLevelUpdatedEvent>,
-        @Qualifier("kycConsumerFactory") consumerFactory: ConsumerFactory<String, KycLevelUpdatedEvent>
-    ) {
+        consumerFactory: ConsumerFactory<String, KycLevelUpdatedEvent>,
+       @Qualifier("kycLevelKafkaTemplate") template: KafkaTemplate<String, KycLevelUpdatedEvent>
+    ): ConcurrentMessageListenerContainer<String, KycLevelUpdatedEvent> {
         val containerProps = ContainerProperties(Pattern.compile("kyc_level_updated"))
         containerProps.messageListener = listener
         val container = ConcurrentMessageListenerContainer(consumerFactory, containerProps)
         container.setBeanName("KycLevelUpdatedKafkaListenerContainer")
         container.commonErrorHandler = createConsumerErrorHandler(template, "kyc_level_updated.DLT")
         container.start()
+        return container
     }
 
     private fun createConsumerErrorHandler(kafkaTemplate: KafkaTemplate<*, *>, dltTopic: String): CommonErrorHandler {

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/data/KycLevelUpdatedEvent.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/data/KycLevelUpdatedEvent.kt
@@ -1,0 +1,9 @@
+package co.nilin.opex.auth.data
+
+import java.time.LocalDateTime
+
+data class KycLevelUpdatedEvent(var userId: String, var kycLevel: KycLevel, var updateDate: LocalDateTime)
+
+enum class KycLevel {
+    LEVEL_1, LEVEL_2, LEVEL_3
+}

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/data/UserRole.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/data/UserRole.kt
@@ -1,0 +1,7 @@
+package co.nilin.opex.auth.data
+
+enum class UserRole(val keycloakName: String) {
+    LEVEL_1("user-1"),
+    LEVEL_2("user-2"),
+    LEVEL_3("user-3"),
+}

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/kafka/KycLevelUpdatedKafkaListener.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/kafka/KycLevelUpdatedKafkaListener.kt
@@ -1,0 +1,26 @@
+package co.nilin.opex.auth.kafka
+
+
+import co.nilin.opex.auth.data.KycLevelUpdatedEvent
+import co.nilin.opex.auth.spi.KycLevelUpdatedEventListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.listener.MessageListener
+import org.springframework.stereotype.Component
+
+@Component
+class KycLevelUpdatedKafkaListener : MessageListener<String, KycLevelUpdatedEvent> {
+    val eventListeners = arrayListOf<KycLevelUpdatedEventListener>()
+    private val logger = LoggerFactory.getLogger(KycLevelUpdatedKafkaListener::class.java)
+    override fun onMessage(data: ConsumerRecord<String, KycLevelUpdatedEvent>) {
+
+        eventListeners.forEach { tl ->
+            logger.info("incoming new event " + tl.id())
+            tl.onEvent(data.value(), data.partition(), data.offset(), data.timestamp(), tl.id())
+        }
+    }
+
+    fun addEventListener(tl: KycLevelUpdatedEventListener) {
+        eventListeners.add(tl)
+    }
+}

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/kafka/KycLevelUpdatedListener.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/kafka/KycLevelUpdatedListener.kt
@@ -1,0 +1,32 @@
+package co.nilin.opex.auth.kafka
+
+import co.nilin.opex.auth.data.KycLevelUpdatedEvent
+import co.nilin.opex.auth.data.UserRole
+import co.nilin.opex.auth.proxy.KeycloakProxy
+import co.nilin.opex.auth.spi.KycLevelUpdatedEventListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class KycLevelUpdatedListener(private val keycloakProxy: KeycloakProxy) : KycLevelUpdatedEventListener {
+
+    private val logger = LoggerFactory.getLogger(KycLevelUpdatedListener::class.java)
+    val scope = CoroutineScope(Dispatchers.IO)
+    override fun id(): String {
+        return "KycLevelUpdatedListener"
+    }
+
+    override fun onEvent(
+        event: KycLevelUpdatedEvent, partition: Int, offset: Long, timestamp: Long, eventId: String
+    ) {
+        logger.info("==========================================================================")
+        logger.info("Incoming UserLevelUpdated event: $event")
+        logger.info("==========================================================================")
+        scope.launch {
+            keycloakProxy.assignRole(event.userId, UserRole.valueOf(event.kycLevel.name))
+        }
+    }
+}

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/service/UserService.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/service/UserService.kt
@@ -3,6 +3,7 @@ package co.nilin.opex.auth.service
 import co.nilin.opex.auth.data.ActionType
 import co.nilin.opex.auth.data.ActiveSession
 import co.nilin.opex.auth.data.UserCreatedEvent
+import co.nilin.opex.auth.data.UserRole
 import co.nilin.opex.auth.kafka.AuthEventProducer
 import co.nilin.opex.auth.model.*
 import co.nilin.opex.auth.proxy.GoogleProxy
@@ -80,7 +81,7 @@ class UserService(
             throw OpexError.BadRequest.exception()
 
         keycloakProxy.confirmCreateUser(user, request.password)
-        keycloakProxy.assignDefaultRoles(user)
+        keycloakProxy.assignRole(user.id, UserRole.LEVEL_1)
 
         // Send event to let other services know a user just registered
         val event = UserCreatedEvent(user.id, user.username, user.email, user.mobile, user.firstName, user.lastName)
@@ -214,5 +215,5 @@ class UserService(
             return TokenData(false, "", OTPAction.REGISTER)
         }
     }
-    
+
 }

--- a/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/spi/KycLevelUpdatedEventListener.kt
+++ b/auth-gateway/auth-gateway-app/src/main/kotlin/co/nilin/opex/auth/spi/KycLevelUpdatedEventListener.kt
@@ -1,0 +1,10 @@
+package co.nilin.opex.auth.spi
+
+import co.nilin.opex.auth.data.KycLevelUpdatedEvent
+
+
+interface KycLevelUpdatedEventListener {
+    fun id(): String
+    fun onEvent(event: KycLevelUpdatedEvent, partition: Int, offset: Long, timestamp: Long, eventId: String)
+
+}

--- a/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/config/AppConfig.kt
+++ b/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/config/AppConfig.kt
@@ -4,20 +4,18 @@ import co.nilin.opex.profile.core.spi.KycLevelUpdatedEventListener
 import co.nilin.opex.profile.core.spi.UserCreatedEventListener
 import co.nilin.opex.profile.ports.kafka.consumer.KycLevelUpdatedKafkaListener
 import co.nilin.opex.profile.ports.kafka.consumer.UserCreatedKafkaListener
-import io.r2dbc.spi.ConnectionFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ClassPathResource
 
 
 @Configuration
 class AppConfig {
     @Autowired
     fun configureEventListeners(
-            useCreatedKafkaListener: UserCreatedKafkaListener,
-            userCreatedEventListener: UserCreatedEventListener,
-            kycLevelUpdatedKafkaListener: KycLevelUpdatedKafkaListener,
-            kycLevelUpdatedEventListener: KycLevelUpdatedEventListener
+        useCreatedKafkaListener: UserCreatedKafkaListener,
+        userCreatedEventListener: UserCreatedEventListener,
+        kycLevelUpdatedKafkaListener: KycLevelUpdatedKafkaListener,
+        kycLevelUpdatedEventListener: KycLevelUpdatedEventListener
     ) {
         useCreatedKafkaListener.addEventListener(userCreatedEventListener)
         kycLevelUpdatedKafkaListener.addEventListener(kycLevelUpdatedEventListener)

--- a/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/service/ProfileApprovalRequestManagement.kt
+++ b/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/service/ProfileApprovalRequestManagement.kt
@@ -33,7 +33,7 @@ class ProfileApprovalRequestManagement(
         val request = changeRequestStatus(id, updater, ProfileApprovalRequestStatus.APPROVED, description)
         val profile = profilePersister.getProfile(request.profileId)?.awaitFirstOrNull()
             ?: throw OpexError.ProfileNotfound.exception()
-        kycLevelUpdatedPublisher.publish(KycLevelUpdatedEvent(profile.userId!!, KycLevel.Level2, LocalDateTime.now()))
+        kycLevelUpdatedPublisher.publish(KycLevelUpdatedEvent(profile.userId!!, KycLevel.LEVEL_2, LocalDateTime.now()))
         return request
     }
 

--- a/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/service/ProfileManagement.kt
+++ b/profile/profile-app/src/main/kotlin/co/nilin/opex/profile/app/service/ProfileManagement.kt
@@ -24,7 +24,6 @@ class ProfileManagement(
     private val linkedAccountPersister: LinkedAccountPersister,
     private val limitationPersister: LimitationPersister,
     private val profileApprovalRequestPersister: ProfileApprovalRequestPersister,
-    private val shahkarInquiry: InquiryProxy,
     private val kycLevelUpdatedPublisher: KycLevelUpdatedPublisher,
     private val otpProxy: OtpProxy,
     private val authProxy: AuthProxy,
@@ -50,7 +49,7 @@ class ProfileManagement(
                     createDate = LocalDateTime.now(),
                     lastUpdateDate = LocalDateTime.now(),
                     creator = "system",
-                    kycLevel = KycLevel.Level1
+                    kycLevel = KycLevel.LEVEL_1
                 )
             )
         }
@@ -169,7 +168,7 @@ class ProfileManagement(
         val profile = profilePersister.getProfile(userId)?.awaitFirstOrNull()
             ?: throw OpexError.ProfileNotfound.exception()
 
-        if (profile.kycLevel == KycLevel.Level2) {
+        if (profile.kycLevel == KycLevel.LEVEL_2) {
             throw OpexError.ProfileAlreadyCompleted.exception()
         }
 
@@ -201,7 +200,7 @@ class ProfileManagement(
 
         if (isIranian) {
             kycLevelUpdatedPublisher.publish(
-                KycLevelUpdatedEvent(userId, KycLevel.Level2, LocalDateTime.now())
+                KycLevelUpdatedEvent(userId, KycLevel.LEVEL_2, LocalDateTime.now())
             )
         } else {
             saveProfileApprovalRequest(completedProfile.id)

--- a/profile/profile-core/src/main/kotlin/co/nilin/opex/profile/core/data/kyc/KycLevel.kt
+++ b/profile/profile-core/src/main/kotlin/co/nilin/opex/profile/core/data/kyc/KycLevel.kt
@@ -1,6 +1,6 @@
 package co.nilin.opex.profile.core.data.kyc
 
 enum class KycLevel {
-    Level1, Level2, Level3
+    LEVEL_1, LEVEL_2, LEVEL_3
 }
 

--- a/profile/profile-core/src/main/kotlin/co/nilin/opex/profile/core/data/kyc/KycLevelDetail.kt
+++ b/profile/profile-core/src/main/kotlin/co/nilin/opex/profile/core/data/kyc/KycLevelDetail.kt
@@ -1,14 +1,14 @@
 package co.nilin.opex.profile.core.data.kyc
 
 enum class  KycLevelDetail(val kycLevel: KycLevel) {
-    Registered(KycLevel.Level1),
-    ProfileCompleted(KycLevel.Level2),
-    UploadDataLevel3(KycLevel.Level2),
-    AcceptedManualReview(KycLevel.Level3),
-    RejectedManualReview(KycLevel.Level2),
-    ManualUpdateLevel1(KycLevel.Level1),
-    ManualUpdateLevel2(KycLevel.Level2),
-    ManualUpdateLevel3(KycLevel.Level3);
+    Registered(KycLevel.LEVEL_1),
+    ProfileCompleted(KycLevel.LEVEL_2),
+    UploadDataLevel3(KycLevel.LEVEL_2),
+    AcceptedManualReview(KycLevel.LEVEL_3),
+    RejectedManualReview(KycLevel.LEVEL_2),
+    ManualUpdateLevel1(KycLevel.LEVEL_1),
+    ManualUpdateLevel2(KycLevel.LEVEL_2),
+    ManualUpdateLevel3(KycLevel.LEVEL_3);
 
 
     public val previousValidSteps: List<KycLevelDetail>?

--- a/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/imp/ProfileManagementImp.kt
+++ b/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/imp/ProfileManagementImp.kt
@@ -95,7 +95,7 @@ class ProfileManagementImp(
             .map { saved ->
                 val response = convertProfileModelToCompleteProfileResponse(saved)
                 if (saved.nationality == NationalityType.IRANIAN) {
-                    response.kycLevel = KycLevel.Level2
+                    response.kycLevel = KycLevel.LEVEL_2
                 }
                 response
             }
@@ -250,7 +250,7 @@ class ProfileManagementImp(
     suspend fun applyMajorChangesRequirements(oldData: ProfileModel, newData: UpdateProfileRequest): KycLevel? {
         //todo
         //read from panel
-        val newKycLevel = KycLevel.Level1
+        val newKycLevel = KycLevel.LEVEL_1
 
         updateKycLevel(userId = oldData.userId!!, kycLevel = newKycLevel, LimitationReason.MajorProfileChange.name)
         limitationManagementImp.updateLimitation(
@@ -268,7 +268,7 @@ class ProfileManagementImp(
     suspend fun applyContactChangesRequirements(oldData: ProfileModel, newData: UpdateProfileRequest): KycLevel? {
         //todo
         //read from panel
-        val newKycLevel = KycLevel.Level1
+        val newKycLevel = KycLevel.LEVEL_1
 
         updateKycLevel(userId = oldData.userId!!, kycLevel = newKycLevel, LimitationReason.MajorProfileChange.name)
         limitationManagementImp.updateLimitation(
@@ -284,7 +284,7 @@ class ProfileManagementImp(
 
     suspend fun updateKycLevel(userId: String, kycLevel: KycLevel, reason: String?) {
         val kycLevelDetail =
-            if (kycLevel == KycLevel.Level1) KycLevelDetail.ManualUpdateLevel1 else KycLevelDetail.ManualUpdateLevel3
+            if (kycLevel == KycLevel.LEVEL_1) KycLevelDetail.ManualUpdateLevel1 else KycLevelDetail.ManualUpdateLevel3
         kycProxyImp.updateKycLevel(ManualUpdateRequest(kycLevelDetail).apply {
             this.userId = userId
             this.description = reason

--- a/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/model/base/Profile.kt
+++ b/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/model/base/Profile.kt
@@ -23,7 +23,7 @@ open class Profile {
     var createDate: LocalDateTime? = null
     var lastUpdateDate: LocalDateTime? = null
     var creator: String? = null
-    var kycLevel: KycLevel? = KycLevel.Level1
+    var kycLevel: KycLevel? = KycLevel.LEVEL_1
     var mobileIdentityMatch : Boolean? = false
     var personalIdentityMatch : Boolean? = false
 

--- a/user-management/user-management-core/src/main/kotlin/co/nilin/opex/auth/core/data/KycLevel.kt
+++ b/user-management/user-management-core/src/main/kotlin/co/nilin/opex/auth/core/data/KycLevel.kt
@@ -1,6 +1,6 @@
 package co.nilin.opex.auth.core.data
 
 enum class KycLevel {
-    Level1, Level2,
+    LEVEL_1, LEVEL_2,LEVEL_3
 }
 


### PR DESCRIPTION
Unified KycLevel enum naming to LEVEL_1, LEVEL_2, LEVEL_3 across all modules. Introduced KycLevelUpdatedEvent, UserRole, and related Kafka listener infrastructure in auth-gateway for handling KYC level update events and assigning user roles in Keycloak. Refactored KeycloakProxy to support dynamic role assignment and improved user update methods. Updated profile and user-management modules to use new KYC level enum names and event publishing.