### PR TITLE
Reset fill history when editing partially filled orders

### DIFF
--- a/matching-engine/matching-engine-core/src/main/kotlin/co/nilin/opex/matching/engine/core/engine/SimpleOrderBook.kt
+++ b/matching-engine/matching-engine-core/src/main/kotlin/co/nilin/opex/matching/engine/core/engine/SimpleOrderBook.kt
@@ -250,7 +250,7 @@ class SimpleOrderBook(val pair: Pair, var replayMode: Boolean) : OrderBook {
             order.matchConstraint,
             order.orderType,
             order.direction,
-            order.filledQuantity,
+            0,
             null,
             null,
             null

--- a/matching-engine/matching-engine-core/src/test/kotlin/co/nilin/opex/matching/engine/core/SimpleOrderBookUnitTest.kt
+++ b/matching-engine/matching-engine-core/src/test/kotlin/co/nilin/opex/matching/engine/core/SimpleOrderBookUnitTest.kt
@@ -565,6 +565,64 @@ class SimpleOrderBookUnitTest {
     }
 
     @Test
+    fun givenPartiallyFilledOrder_whenEditQuantity_thenRequestedQuantityRests() {
+        val orderBook = SimpleOrderBook(pair, false)
+        val ask = orderBook.handleNewOrderCommand(
+            OrderCreateCommand(
+                UUID.randomUUID().toString(),
+                uuid,
+                pair,
+                100,
+                10,
+                OrderDirection.ASK,
+                MatchConstraint.GTC,
+                OrderType.LIMIT_ORDER
+            )
+        )!!
+        orderBook.handleNewOrderCommand(
+            OrderCreateCommand(
+                UUID.randomUUID().toString(),
+                uuid,
+                pair,
+                100,
+                4,
+                OrderDirection.BID,
+                MatchConstraint.GTC,
+                OrderType.LIMIT_ORDER
+            )
+        )
+
+        val edited = orderBook.handleEditCommand(
+            OrderEditCommand(
+                UUID.randomUUID().toString(),
+                uuid,
+                ask.id()!!,
+                pair,
+                101,
+                6
+            )
+        ) as SimpleOrder
+
+        Assertions.assertEquals(0, edited.filledQuantity)
+        Assertions.assertEquals(6, edited.remainedQuantity())
+        Assertions.assertEquals(6, orderBook.askOrders[101]?.totalQuantity)
+
+        val aggressor = orderBook.handleNewOrderCommand(
+            OrderCreateCommand(
+                UUID.randomUUID().toString(),
+                uuid,
+                pair,
+                101,
+                6,
+                OrderDirection.BID,
+                MatchConstraint.IOC,
+                OrderType.LIMIT_ORDER
+            )
+        ) as SimpleOrder
+        Assertions.assertEquals(6, aggressor.filledQuantity)
+    }
+
+    @Test
     fun givenEmptyOrderBook_whenGtcBidMarketOrderCreated_thenRejected() {
         //given
         val orderBook = SimpleOrderBook(pair, false)


### PR DESCRIPTION
Fixes the matching-semantic part of #688. The separate performance observations in that issue are intentionally out of scope here.

## What changed

- Reset `filledQuantity` when an edit rebuilds an order through the existing cancel-and-reinsert path.
- Add a native lifecycle regression: rest 10, fill 4, edit the remaining order to quantity 6 at a new price, then consume all 6 with an IOC.

Before the fix, the edited order carried the old fill count of 4 and exposed only 2 units. Against the original line, the new test fails with `expected: <0> but was: <4>`; with the fix, the requested 6 units rest and fill.

## Verification

```
JAVA_HOME=<jdk-17> mvn -B -pl matching-engine/matching-engine-core -am \
  -Dskip.unit.tests=false -Dsurefire.failIfNoSpecifiedTests=false \
  -Dtest=SimpleOrderBookUnitTest test
```

Result: 18 passed, 0 failed under Java 17.
