### PR TITLE
Disable mobile format validation on profile

### DIFF
--- a/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/imp/ProfileManagementImp.kt
+++ b/profile/profile-ports/profile-postgres/src/main/kotlin/co/nilin/opex/profile/ports/postgres/imp/ProfileManagementImp.kt
@@ -196,7 +196,7 @@ class ProfileManagementImp(
     }
 
     override suspend fun validateMobileForUpdate(userId: String, mobile: String) {
-        validateMobileFormat(mobile)
+//        validateMobileFormat(mobile)
 
         val profile = profileRepository.findByUserId(userId)?.awaitFirstOrNull()
             ?: throw OpexError.ProfileNotfound.exception()


### PR DESCRIPTION
Comment out the call to validateMobileFormat(mobile) in ProfileManagementImp.validateMobileForUpdate so mobile format checking is skipped during mobile updates. Repository lookup and existing error handling remain unchanged.